### PR TITLE
Fix for 1.9

### DIFF
--- a/src/main/java/uk/co/ks07/uhome/metrics/Metrics.java
+++ b/src/main/java/uk/co/ks07/uhome/metrics/Metrics.java
@@ -361,7 +361,7 @@ public class Metrics {
         data.append(encode("guid")).append('=').append(encode(guid));
         encodeDataPair(data, "version", description.getVersion());
         encodeDataPair(data, "server", Bukkit.getVersion());
-        encodeDataPair(data, "players", Integer.toString(Bukkit.getServer().getOnlinePlayers().length));
+        encodeDataPair(data, "players", Integer.toString(Bukkit.getServer().getOnlinePlayers().size()));
         encodeDataPair(data, "revision", String.valueOf(REVISION));
 
         // If we're pinging, append it


### PR DESCRIPTION
getOnlinePlayers() returns a Collection rather than an array as of Spigot 1.9
